### PR TITLE
Update sign.py to fix curve class warning

### DIFF
--- a/python/sign.py
+++ b/python/sign.py
@@ -81,7 +81,7 @@ class CSR:
         self.csr_pem = self.csr_pem_bytes.decode('UTF-8')
 
     def _generate_private_key(self):
-        return ec.generate_private_key(ec.SECP384R1)
+    	return ec.generate_private_key(ec.SECP384R1(), backend=None)
 
     # Returns CSR PEM bytes
     def _generate_csr(self):


### PR DESCRIPTION
Fix for Deprecation warning

sign.py:84: CryptographyDeprecationWarning: Curve argument must be an instance of an EllipticCurve class. Did you pass a class by mistake? This will be an exception in a future version of cryptography.
  return ec.generate_private_key(ec.SECP384R1)

The warning message is from the cryptography library, indicating that one should pass an instance of the curve, rather than the curve class itself. Currently, sign.py passes the curve class (ec.SECP384R1), but should instantiate it as an object.